### PR TITLE
feat: Select the same destination PDF version as the input file

### DIFF
--- a/shrinkpdf.sh
+++ b/shrinkpdf.sh
@@ -76,8 +76,8 @@ check_smaller() {
   if [ ! -f "$1" ] || [ ! -f "$2" ]; then
     return 0
   fi
-  ISIZE="$(echo "$(wc -c "$1")" | cut -f1 -d\ )"
-  OSIZE="$(echo "$(wc -c "$2")" | cut -f1 -d\ )"
+  ISIZE="$(wc -c "$1" | cut -f1 -d\ )"
+  OSIZE="$(wc -c "$2" | cut -f1 -d\ )"
   if [ "$ISIZE" -lt "$OSIZE" ]; then
     echo "Input smaller than output, doing straight copy" >&2
     cp "$1" "$2"


### PR DESCRIPTION
This reads the PDF version of the input file. And then uses the same version for the output file.

I noticed that if I shrink a PDF of version 1.5, then the resulting PDF is often larger than the input. If the output file is however of version 1.5, then the output file is smaller than the input.